### PR TITLE
- Refactor init script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,14 @@
 FROM alpine:edge
-MAINTAINER Nemo Alex <zhhjchina@gmail.com>
+MAINTAINER OpenGG <liy099@gmail.com>
+
+COPY root/ /
 
 RUN set -xe \
-    && apk add --no-cache aria2 \
-    && aria2c https://github.com/tianon/gosu/releases/download/1.7/gosu-amd64 -o /usr/local/bin/gosu \
-    && chmod +x /usr/local/bin/gosu \
-    && adduser -D aria2 \
-    && mkdir /home/aria2/downloads
+    && apk add --no-cache aria2 su-exec \
+    && chmod +x /init.sh
 
-VOLUME /home/aria2/downloads /etc/aria2
+VOLUME /config /downloads
 
 EXPOSE 6800
-CMD set -xe \
-    && chown -R aria2:aria2 /home/aria2 \
-    && chown -R aria2:aria2 /etc/aria2 \
-    && gosu aria2 aria2c --conf-path=/etc/aria2/aria2.conf \
-                         --rpc-listen-port=6800 \
-                         --dir=/home/aria2/downloads
+
+CMD ["/init.sh"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,65 @@
 # docker-aria2
 
-[Dockernize aria2](https://hub.docker.com/r/nemoalex/aria2/)
+## Usage
 
-See https://github.com/NemoAlex/docker-compose-aria2
+0. `mkdir` a config dir, say `/storage/aria2`
+
+0. Put `aria2.conf` file in the config dir, with following content.
+[Config reference](https://aria2.github.io/manual/en/html/aria2c.html#aria2-conf)
+    ```
+    save-session=/config/aria2.session
+    input-file=/config/aria2.session
+    save-session-interval=60
+
+    file-allocation=prealloc
+    disk-cache=128M
+
+    enable-rpc=true
+    rpc-allow-origin-all=true
+    rpc-listen-all=true
+    rpc-secret=<password>
+
+    auto-file-renaming=false
+    ```
+0. Run following command to start aria2 instance
+    ```
+    docker run \
+      -d \
+      --name aria2 \
+      -e PGID=<gid> \
+      -e PUID=<uid> \
+      -v <path to config>:/config \
+      -v <path to downloads>:/downloads \
+      -p 6800:6800 \
+      opengg/aria2
+    ```
+
+Note:
+Make sure the download folder is writable by the given uid/gid.
+
+## Parameters
+
+The parameters are split into two halves, separated by a colon, the left hand side representing the host and the right the container side.
+For example with a port -p external:internal - what this shows is the port mapping from internal to external of the container.
+So -p 8080:80 would expose port 80 from inside the container to be accessible from the host's IP on port 8080
+`http://192.168.x.x:8080` would show you what's running INSIDE the container on port 80.
+
+
+* `-p 6800` - the port(s)
+* `-v /config` - where aria2 should store config files and logs
+* `-v /downloads` - local path for downloads
+* `-e PGID` for GroupID - see below for explanation
+* `-e PUID` for UserID - see below for explanation
+
+It is based on alpine linux, for shell access whilst the container is running do `docker exec -it aria2 /bin/sh`.
+
+### User / Group Identifiers
+
+Sometimes when using data volumes (`-v` flags) permissions issues can arise between the host OS and the container. We avoid this issue by allowing you to specify the user `PUID` and group `PGID`. Ensure the data volume directory on the host is owned by the same user you specify and it will "just work" ™.
+
+In this instance `PUID=1001` and `PGID=1001`. To find yours use `id user` as below:
+
+```
+  $ id <dockeruser>
+    uid=1001(dockeruser) gid=1001(dockergroup) groups=1001(dockergroup)
+```

--- a/root/aria2.conf.default
+++ b/root/aria2.conf.default
@@ -1,0 +1,17 @@
+save-session=/config/aria2.session
+input-file=/config/aria2.session
+save-session-interval=60
+
+dir=/downloads
+
+enable-rpc=true
+rpc-listen-port=6800
+rpc-allow-origin-all=true
+rpc-listen-all=true
+
+file-allocation=prealloc
+disk-cache=128M
+
+rpc-secret=<password>
+
+auto-file-renaming=false

--- a/root/init.sh
+++ b/root/init.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+set -e
+
+_term() {
+  echo "Caught SIGTERM signal, exiting pid ${pid}"
+  kill -TERM "$pid" 2>/dev/null
+  echo "[DONE]"
+}
+
+UID=${PUID:-1024}
+GID=${PGID:-1024}
+
+echo
+echo "UID: ${UID}"
+echo "GID: ${GID}"
+echo
+
+echo "Setting conf"
+
+touch /config/aria2.session
+touch /config/aria2.log
+touch /config/aria2.err
+
+if [[ ! -e /config/aria2.conf ]]
+then
+  cp /aria2.conf.default /config/aria2.conf
+fi
+
+echo "[DONE]"
+
+echo "Setting owner and permissions"
+
+chown -R ${UID}:${GID} /config
+find /config -type d -exec chmod 755 {} +
+find /config -type f -exec chmod 644 {} +
+
+echo "[DONE]"
+
+trap _term SIGTERM
+
+echo "Starting aria2c";
+
+su-exec ${UID}:${GID} \
+    aria2c \
+        --enable-rpc \
+        --conf-path=/config/aria2.conf \
+        --rpc-listen-port=6800 \
+     > /config/aria2.log \
+    2> /config/aria2.err &
+
+pid=$!
+
+echo "aria2c started with pid ${pid}"
+
+wait "$pid"


### PR DESCRIPTION
- Default configs
- stdout and stderr logs
- SIGTERM graceful exit
- Detailed readme
- Use su-exec instead of gosu
- Setup UID/GID, like linuxserver family
- Fix permissions and owners on start